### PR TITLE
Add action to upload to dockerhub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/enigma-pd-wml
+          tags:
+            type=semver,pattern={{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
For https://github.com/UCL-ARC/Enigma-PD-WML/issues/10

This workflow is based on a mix of info in the [github docs](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images) and the [docker docs](https://docs.docker.com/build/ci/github-actions/).

On release it should:
- login to docker
- Build the image and tag it with the version of the github release (e.g. `v1.0.2`)
- Upload to the docker repository: https://hub.docker.com/r/hamiedaharoon24/enigma-pd-wml