### PR TITLE
Correct BIDS directory structure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish Docker and Apptainer images
 
 on:
+  workflow_dispatch:
   release:
     types:
       - published

--- a/README.md
+++ b/README.md
@@ -175,36 +175,38 @@ image.
 After running your analysis, your data directory should have the following structure:
 
 ```bash
-data
+bids-data
 ├── dataset_description.json
-├── enigma-pd-wml.log
-├── enigma-pd-wml-results.zip
-├── sub-1
-│   ├── ses-1
-│   │   ├── anat
-│   │   │   ├── sub-1_ses-1_FLAIR.nii.gz
-│   │   │   └── sub-1_ses-1_T1w.nii.gz
-│   │   └── derivatives
-│   │       └── enigma-pd-wml
-│   │           ├── input/
-│   │           ├── output/
-│   │           ├── sub-1_ses-1.log
-│   │           └── sub-1_ses-1_results.zip
-│   └── ses-2
-│       ├── anat
-│       │   ├── sub-1_ses-2_FLAIR.nii.gz
-│       │   └── sub-1_ses-2_T1w.nii.gz
-│       └── derivatives
-│           └── enigma-pd-wml
+├── derivatives
+│   └── enigma-pd-wml
+│       ├── enigma-pd-wml.log
+│       └── sub-1
+│           ├── ses-1
+│           │   ├── input/
+│           │   ├── output/
+│           │   ├── sub-1_ses-1.log
+│           │   └── sub-1_ses-1_results.zip
+│           └── ses-2
 │               ├── input/
 │               ├── output/
 │               ├── sub-1_ses-2.log
 │               └── sub-1_ses-2_results.zip
+├── sub-1
+│   ├── ses-1
+│   │   └── anat
+│   │       ├── sub-1_ses-1_FLAIR.nii.gz
+│   │       └── sub-1_ses-1_T1w.nii.gz
+│   └── ses-2
+│       └── anat
+│           ├── sub-1_ses-2_FLAIR.nii.gz
+│           └── sub-1_ses-2_T1w.nii.gz
+└── subjects.txt
 ```
 
 #### Session-level zip files
 
-The pipeline will generate multiple `.zip` files - one per session, e.g. `sub-1_ses-1_results.zip`.
+The pipeline will generate multiple `.zip` files - one per session, stored within the corresponding session
+sub-folder, e.g. `derivatives/enigma-pd-wml/sub-1/ses-1/sub-1_ses-1_results.zip`.
 
 These zip files should contain six files:
 
@@ -222,23 +224,24 @@ These zip files should contain six files:
 
 #### Top-level zip file
 
-A top-level zip file will also be created (`enigma-pd-wml-results.zip`). This will contain all zip files for each session.
+A top-level zip file will also be created (`derivatives/enigma-pd-wml/enigma-pd-wml-results.zip`). This will contain all
+zip files for each session.
 
 **Please send this top-level zip file to the ENIGMA-PD Vasc team.**
 
 #### Intermediate files
 
-The pipeline generates several intermediate files. These are stored in the `derivatives/enigma-pd-wml/input` and
-`derivatives/enigma-pd-wml/output` folders of each session.
+The pipeline generates several intermediate files. These are stored in the `derivatives/enigma-pd-wml/<subject>/<session>/input`
+and `derivatives/enigma-pd-wml/<subject>/<session>/output` folders.
 
 ### Output logs
 
 Pipeline logs can be found at:
 
-- `enigma-pd-wml.log`: contains minimal information about the initial pipeline setup.
+- `derivatives/enigma-pd-wml/enigma-pd-wml.log`: contains minimal information about the initial pipeline setup.
 
-- `enigma-pd-wml/<subject>_<session>.log`: one log per session; stored in the session's `derivatives folder`;
-  contains information about the various processing steps.
+- `derivatives/enigma-pd-wml/<subject>/<session>/<subject>_<session>.log`: one log per session; contains information about
+  the various processing steps.
 
 ## Common issues
 

--- a/analysis_script.sh
+++ b/analysis_script.sh
@@ -305,7 +305,7 @@ function runAnalysis (){
 
    subject=$1
    session=$2
-   echo "Processing subject: ${subject} session: ${session}" >> ${data_path}/enigma-pd-wml.log
+   echo "Processing subject: ${subject} session: ${session}" >> ${data_path}/derivatives/enigma-pd-wml/enigma-pd-wml.log
    echo subject : ${subject}
    echo session : ${session}
 
@@ -318,7 +318,7 @@ function runAnalysis (){
    echo
 
    # assign path for output data directory and create it (if it doesn't exist)
-   export data_outpath=${data_path}/${subject}/${session}/derivatives/enigma-pd-wml/
+   export data_outpath=${data_path}/derivatives/enigma-pd-wml/${subject}/${session}
    mkdir -p ${data_outpath}
    echo data_outpath : ${data_outpath}
 
@@ -389,7 +389,7 @@ function setupRunAnalysis(){
     sessions=$(find ${data_path}/${subject}/ses-*/anat/${subject}_ses-*_T1w.nii.gz | xargs -n 1 dirname | xargs -n 1 dirname | xargs -n 1 basename)  #
     for session in $sessions; do
       subjects_sessions+=("${subject} ${session}")
-      mkdir -p ${data_path}/${subject}/${session}/derivatives/enigma-pd-wml/
+      mkdir -p ${data_path}/derivatives/enigma-pd-wml/${subject}/${session}
     done
   done < $subjects_list
 
@@ -400,15 +400,15 @@ function setupRunAnalysis(){
     for subject_session in "${subjects_sessions[@]}"; do
       subject=$(echo $subject_session | cut -d ' ' -f 1)
       session=$(echo $subject_session | cut -d ' ' -f 2)
-      runAnalysis $subject $session > "${data_path}/${subject}/${session}/derivatives/enigma-pd-wml/${subject}_${session}.log" 2>&1
+      runAnalysis $subject $session > "${data_path}/derivatives/enigma-pd-wml/${subject}/${session}/${subject}_${session}.log" 2>&1
     done
   else
     echo "Running in parallel with ${n} jobs"
     export -f runAnalysis fslAnat flairPrep ventDistMapping prepImagesForUnet unetsPgs processOutputs allFilesExist
-    printf "%s\n" "${subjects_sessions[@]}" | parallel --jobs ${n} --colsep ' ' runAnalysis \{1\} \{2\} ">" "'${data_path}/{1}/{2}/derivatives/enigma-pd-wml/{1}_{2}.log'" "2>&1"
+    printf "%s\n" "${subjects_sessions[@]}" | parallel --jobs ${n} --colsep ' ' runAnalysis \{1\} \{2\} ">" "'${data_path}/derivatives/enigma-pd-wml/{1}/{2}/{1}_{2}.log'" "2>&1"
   fi
 
-  zip -q enigma-pd-wml-results.zip ${data_path}/sub-*/ses-*/derivatives/enigma-pd-wml/sub-*_ses*_results.zip
+  zip -q ${data_path}/derivatives/enigma-pd-wml/enigma-pd-wml-results.zip ${data_path}/derivatives/enigma-pd-wml/sub-*/ses-*/sub-*_ses*_results.zip
 
   echo
   echo =====================================================
@@ -423,8 +423,10 @@ function setupRunAnalysis(){
 
 # assign paths for code and input data directories, as well as overall log file
 export data_path=/data
-overall_log=${data_path}/enigma-pd-wml.log
+mkdir -p ${data_path}/derivatives/enigma-pd-wml/
+overall_log=${data_path}/derivatives/enigma-pd-wml/enigma-pd-wml.log
 
 echo "Running analysis script"
-echo "See overall log at enigma-pd-wml.log and subject/session logs with the derivatives folders of each session"
+echo "See overall log at derivatives/enigma-pd-wml/enigma-pd-wml.log"
+echo "See logs for each session in their respective folders: derivatives/enigma-pd-wml/sub-*/ses-*/"
 setupRunAnalysis "$@" >> $overall_log 2>&1

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -24,7 +24,7 @@ flowchart TD
 ## fsl_anat
 
 First, FSL's `fsl_anat` tool is run on the input T1 image and its output saved to
-`derivatives/enigma-pd-wml/input/t1-mni.anat` folder of each session.
+`derivatives/enigma-pd-wml/<subject>/<session>/input/t1-mni.anat` folder of each session.
 
 [See FSL's documentation](https://fsl.fmrib.ox.ac.uk/fsl/docs/#/structural/fsl_anat) for details of the various
 processing steps this includes.
@@ -32,7 +32,7 @@ processing steps this includes.
 ## FLAIR preparation
 
 Next, various FSL tools are used to pre-process the input FLAIR image and align it to the T1 image. Results are written
-to the `derivatives/enigma-pd-wml/input/flair-bet` directory of each session. This includes steps to:
+to the `derivatives/enigma-pd-wml/<subject>/<session>/input/flair-bet` directory of each session. This includes steps to:
 
 - Re-orient the FLAIR image to the standard (MNI) orientation with `fslreorient2std`
 
@@ -47,7 +47,7 @@ to the `derivatives/enigma-pd-wml/input/flair-bet` directory of each session. Th
 
 Next, various FSL tools are used to create periventricular vs deep white matter masks for both the T1 and FLAIR images.
 These will be used at a later stage to divide WML segmentations into periventicular vs deep white matter. Results are
-written to the `derivatives/enigma-pd-wml/input/vent_dist_mapping` directory of each session.
+written to the `derivatives/enigma-pd-wml/<subject>/<session>/input/vent_dist_mapping` directory of each session.
 
 This includes steps to:
 
@@ -67,7 +67,7 @@ FLAIR images with `fslroi` (if they're larger than 500 pixels in the x or y dime
 
 Run the UNet-pgs segmentation workflow. This uses the `WMHs_segmentation_PGS.sh` script from
 [the pgs docker image](https://hub.docker.com/r/cvriend/pgs/tags). This will produce a WML binary segmentation mask
-under the `derivatives/enigma-pd-wml/output/results.nii.gz` of each session.
+under the `derivatives/enigma-pd-wml/<subject>/<session>/output/results.nii.gz` of each session.
 
 ## Process outputs of UNets-pgs
 
@@ -89,8 +89,10 @@ This includes steps to:
 
 ## Final pipeline outputs
 
-The pipeline will generate multiple `.zip` files - one per session, e.g. `sub-1_ses-1_results.zip`. These are
-stored in the `derivatives/enigma-pd-wml/` directory of each session.
+The pipeline will generate multiple `.zip` files - one per session, stored within the corresponding session
+sub-folder, e.g. `derivatives/enigma-pd-wml/sub-1/ses-1/sub-1_ses-1_results.zip`.
 
-A top-level zip file will also be created (`enigma-pd-wml-results.zip`). This will contain all zip files for each session.
+A top-level zip file will also be created (`derivatives/enigma-pd-wml/enigma-pd-wml-results.zip`). This will contain all
+zip files for each session.
+
 **Please send this top-level zip file to the ENIGMA-PD Vasc team.**


### PR DESCRIPTION
#24 added support for BIDS but added the outputs to the incorrect directories.

This PR:
- adds the `data/derivatives` folder for all outputs
- updates docs