### PR TITLE
Increase disk space available to runner in `publish.yaml` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           apptainer remote add --tokenfile ~/.apptainer/sylabs-token sylabs https://cloud.sylabs.io
 
-      - name: Build and push SIF image
+      - name: Build and push Apptainer image
         run: |
           TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1 | awk -F':' '{print $2}')
           apptainer build container.sif docker-daemon://${{ secrets.DOCKERHUB_USERNAME }}/enigma-pd-wml:$TAG

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,6 @@
 name: Publish Docker and Apptainer images
 
 on:
-  workflow_dispatch:
   release:
     types:
       - published
@@ -12,18 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-      - name: Check disk space
-        run: df -h
-
-      - name: "node-cleanup"
+      - name: Increase disk space available for building images
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc "$AGENT_TOOLSDIRECTORY"
           sudo docker image prune --all --force
           sudo docker builder prune -a
-
-      - name: Check disk space
-        run: df -h
 
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -42,19 +34,13 @@ jobs:
           tags:
             type=semver,pattern={{version}}
 
-      - name: Check disk space
-        run: df -h
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Check disk space
-        run: df -h
 
       - name: Install Apptainer
         run: |
@@ -62,9 +48,6 @@ jobs:
           sudo apt install -y software-properties-common && \
           sudo add-apt-repository -y ppa:apptainer/ppa && \
           sudo apt install -y apptainer
-
-      - name: Check disk space
-        run: df -h
 
       - name: Write token for Sylabs Cloud
         env:
@@ -82,6 +65,4 @@ jobs:
         run: |
           TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1 | awk -F':' '{print $2}')
           apptainer build container.sif docker-daemon://${{ secrets.DOCKERHUB_USERNAME }}/enigma-pd-wml:$TAG
-
-      - name: Check disk space
-        run: df -h
+          apptainer push -U container.sif library://${{ secrets.SYLABS_USERNAME }}/enigma-pd-wml/enigma-pd-wml:$TAG

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Check disk space
+        run: df -h
+
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc "$AGENT_TOOLSDIRECTORY"
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+
+      - name: Check disk space
+        run: df -h
+
       - name: Check out the repo
         uses: actions/checkout@v4
 
@@ -29,13 +42,19 @@ jobs:
           tags:
             type=semver,pattern={{version}}
 
+      - name: Check disk space
+        run: df -h
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Check disk space
+        run: df -h
 
       - name: Install Apptainer
         run: |
@@ -43,6 +62,9 @@ jobs:
           sudo apt install -y software-properties-common && \
           sudo add-apt-repository -y ppa:apptainer/ppa && \
           sudo apt install -y apptainer
+
+      - name: Check disk space
+        run: df -h
 
       - name: Write token for Sylabs Cloud
         env:
@@ -60,4 +82,6 @@ jobs:
         run: |
           TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1 | awk -F':' '{print $2}')
           apptainer build container.sif docker-daemon://${{ secrets.DOCKERHUB_USERNAME }}/enigma-pd-wml:$TAG
-          apptainer push -U container.sif library://${{ secrets.SYLABS_USERNAME }}/enigma-pd-wml/enigma-pd-wml:$TAG
+
+      - name: Check disk space
+        run: df -h


### PR DESCRIPTION
#25 added support for publishing Apptainer images. However, building the Apptainer image currently [fails](https://github.com/UCL-ARC/Enigma-PD-WML/actions/runs/12891934178/job/35945530388#step:9:90) due to lack of disk space on the runner:
> FATAL:   While performing build: conveyor failed to get: while converting reference: copying contents to temporary file "/tmp/bundle-temp-1185264276/container_images_docker-tar1010821903": write /tmp/bundle-temp-1185264276/container_images_docker-tar1010821903: no space left on device
