### PR TITLE
Run Apptainer with images published on Docker Hub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Docker and Apptainer images
+name: Publish Docker image
 
 on:
   release:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    name: Build and publish images to Docker Hub and Sylabs Cloud
+    name: Build and publish image to Docker Hub
     runs-on: ubuntu-latest
 
     steps:
@@ -47,28 +47,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Install Apptainer
-        run: |
-          sudo apt update && \
-          sudo apt install -y software-properties-common && \
-          sudo add-apt-repository -y ppa:apptainer/ppa && \
-          sudo apt install -y apptainer
-
-      - name: Write token for Sylabs Cloud
-        env:
-          SYLABS_TOKEN: ${{ secrets.SYLABS_TOKEN }}
-        run: |
-          mkdir -p ~/.apptainer
-          echo "${SYLABS_TOKEN}" > ~/.apptainer/sylabs-token
-          chmod 600 ~/.apptainer/sylabs-token
-
-      - name: Configure Sylabs Library endpoint
-        run: |
-          apptainer remote add --tokenfile ~/.apptainer/sylabs-token sylabs https://cloud.sylabs.io
-
-      - name: Build and push Apptainer image
-        run: |
-          TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1 | awk -F':' '{print $2}')
-          apptainer build enigma-pd-wml.sif docker-daemon://${{ secrets.DOCKERHUB_USERNAME }}/enigma-pd-wml:$TAG
-          apptainer push -U enigma-pd-wml.sif library://${{ secrets.SYLABS_USERNAME }}/enigma-pd-wml/enigma-pd-wml:$TAG

--- a/README.md
+++ b/README.md
@@ -104,27 +104,30 @@ image.
 
 ### Using Apptainer
 
-The image is available on Sylabs Cloud in the
-[hh-enigmapd-2025/enigma-pd-wml/enigma-pd-wml](https://cloud.sylabs.io/library/hh-enigmapd-2025/enigma-pd-wml/enigma-pd-wml)
-repository.
-
-To run the analysis using Apptainer:
+To run the analysis with Apptainer, you will first need to build an image based on the Docker image
+available on Docker Hub.
 
 ```bash
-apptainer run --bind "${PWD}":/data library://hh-enigmapd-2025/enigma-pd-wml/enigma-pd-wml:<tag>
+apptainer build enigma-pd-wml.sif docker://hamiedaharoon24/enigma-pd-wml:<tag>
 ```
 
 where `<tag>` is the version of the image you would like to pull.
 
-It can sometime be slow to pull the image from Sylabs Cloud. If you would prefer to pull the Docker image
-from Docker Hub and build and run a local Apptainer image, you can run the following command:
+This will create an `enigma-pd-wml.sif` image in your current working directory.
+
+To run the analysis:
 
 ```bash
-apptainer run --bind "${PWD}":/data docker://hamiedaharoon24/enigma-pd-wml:<tag>
+apptainer run --bind "${PWD}":/data enigma-pd-wml.sif
 ```
 
-Note, the image will be downloaded from Sylabs Cloud (or Docker Hub) the first time you run a particular version of the
-image.
+where `<tag>` is the version of the image you would like to pull.
+
+Note, this requires either:
+
+- the `enigma-pd-wml.sif` file is in your current working
+  directory (which should be your top-level BIDS data directory)
+- or, you provide the full path to the `.sif` file in the command
 
 ### Options
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -46,9 +46,10 @@ After building the Apptainer image, you can run a container based on this local 
 apptainer run --bind "${PWD}"/data:/data enigma-pd-wml.sif
 ```
 
-Note, this requires your BIDS data is stored in the directory `Enigma-PD-WML/data`.
+Note, this requires your BIDS data is stored in the directory `Enigma-PD-WML/data`, and that `enigma-pd-wml.sif`
+is in the `Enigma-PD-WML` directory.
 
-## Making new releases to docker hub and Sylabs Cloud
+## Making new releases to docker hub
 
 This repository has a github actions workflow to automate uploading to
 [Docker Hub](https://hub.docker.com/r/hamiedaharoon24/enigma-pd-wml/tags) when a new release is made on github.
@@ -63,32 +64,6 @@ This repository has a github actions workflow to automate uploading to
 
 - This will trigger the action to run and upload the code on the `main` branch to Docker Hub and Sylabs Cloud. Note: as
   the images are very large, this will take a while! (around 40 minutes)
-
-### Publishing to Sylabs Cloud
-
-We publish the Apptainer image to Sylabs Cloud. However, API access tokens to Sylabs Cloud only last for
-two weeks.
-
-If the token has expired, you will need to create a new one and add it as a repository secret.
-
-Instructions for @HamiedGH:
-
-#### 1. Create an API Access Token in Sylabs Cloud
-
-1. Log in to your account on [Sylabs Cloud](https://cloud.sylabs.io).
-2. Click on your profile icon in the top right corner and select "Access Tokens".
-3. Click on "Create Token".
-4. Enter a name for the token and click "Create".
-5. Copy the generated token. You will need this in the next step.
-
-#### 2. Add the token as a repository secret in GitHub
-
-1. Go to the [Enigma-PD-WML repository](https://github.com/UCL-ARC/Enigma-PD-WML) on GitHub.
-2. Click on the "Settings" tab.
-3. In the left sidebar, click on "Secrets and variables" and then "Actions".
-4. Click the edit buttion next to the `SYLABS_TOKEN` secret.
-5. Paste the token you copied from Sylabs Cloud into the "Secret" field.
-6. Click "Update secret".
 
 ## Linting setup (pre-commit)
 


### PR DESCRIPTION
The goal of #21 was to have versioned Apptainer images. However:
- there is a limit of 11 GB per repository on Sylabs Cloud (and our image is nearly 6 GB, so we can't publish a second version)
- API access keys to Sylabs Cloud only last for 2 weeks
- it is very slow to download images from Sylabs Cloud

Instead, update docs to show how to build a local Apptainer image using a specific version of the image on Docker Hub, and then run the analysis with this local image.
