### PR TITLE
Add periventricular and deep white matter segmentations in the original T1 space

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ data
 The pipeline will generate multiple `.zip` files - one per session, stored within the corresponding session
 sub-folder, e.g. `derivatives/enigma-pd-wml/sub-1/ses-1/sub-1_ses-1_results.zip`.
 
-These zip files should contain six files:
+These zip files should contain 10 files:
 
 - `results2mni_lin.nii.gz`: WML segmentations linearly transformed to MNI space.
 

--- a/analysis_script.sh
+++ b/analysis_script.sh
@@ -270,6 +270,14 @@ function processOutputs(){
    fslmaths results2flairfullfov.nii.gz -mul perivent_flairbrain.nii.gz results2flairfullfov_perivent
    fslmaths results2flairfullfov.nii.gz -mul dwm_flairbrain.nii.gz results2flairfullfov_deep
 
+   # run FSL's flirt tool to transform/align WML periventricular and deep white matter portions with full-fov T1
+   flirt -in results2t1roi_perivent.nii.gz -applyxfm -init T1_roi2nonroi.mat \
+     -out results2t1fullfov_perivent \
+     -paddingsize 0.0 -interp nearestneighbour -ref T1_fullfov.nii.gz
+
+   flirt -in results2t1roi_deep.nii.gz -applyxfm -init T1_roi2nonroi.mat \
+     -out results2t1fullfov_deep \
+     -paddingsize 0.0 -interp nearestneighbour -ref T1_fullfov.nii.gz
 
    echo "STEP 04"
    # run FSL's flirt tool to linearly transform/align WML segmentations with MNI T1


### PR DESCRIPTION
- run FSL's flirt tool to transform/align WML periventricular and deep white matter portions with full-fov T1
- fix typo in README that mentions the number of output files